### PR TITLE
Add a no-ouput silent mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ npm-debug.*
 .sass-cache
 node_modules
 test.html
+tmp

--- a/gorko.scss
+++ b/gorko.scss
@@ -2,6 +2,9 @@
 // the user hasn't yet set a config for their project
 @import './src/default-config';
 
+// Set default feature flags
+$outputTokenCSS: true !default;
+
 @import './src/functions/functions';
 @import './src/mixins/mixins';
 @import './src/generator/generator';

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
   "name": "gorko",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A tiny Sass token class generator.",
   "main": "gorko.scss",
   "dependencies": {
     "sass": "^1.26.5"
+  },
+  "scripts": {
+    "test": "npx sass gorko.scss tmp/gorko.css"
   },
   "devDependencies": {},
   "repository": {

--- a/src/generator/_generator.scss
+++ b/src/generator/_generator.scss
@@ -1,14 +1,17 @@
 @import 'workers/cycle';
 
-// Run the standard cycle first
-@include cycle('', false);
+// Only run if there should be an output
+@if ($outputTokenCSS == true) {
+  // Run the standard cycle first
+  @include cycle('', false);
 
-// For each breakpoint, generate a prefix and run the cycle
-@each $key, $value in map-get($gorko-config, 'breakpoints') {
-  $prefix: #{$key + '\\:'};
-  $is-breakpoint: true;
+  // For each breakpoint, generate a prefix and run the cycle
+  @each $key, $value in map-get($gorko-config, 'breakpoints') {
+    $prefix: #{$key + '\\:'};
+    $is-breakpoint: true;
 
-  @media screen and #{$value} {
-    @include cycle($prefix, $is-breakpoint);
+    @media screen and #{$value} {
+      @include cycle($prefix, $is-breakpoint);
+    }
   }
 }


### PR DESCRIPTION
This is so Gorko and a token config can be included and not generate
a bundle CSS output which is handy for splitting