### PR TITLE
Fix get-config-value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gorko",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A tiny Sass token class generator.",
   "main": "gorko.scss",
   "dependencies": {

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ A tiny, Sass-powered utility class generator, with handy helpers, that helps you
   * [Sass functions](#sass-functions)
     + [`get-color($key: string)`](#-get-color--key--string--)
       - [Example](#example)
-    + [get-config-value($key: string, $group: string)](#get-config-value--key--string---group--string-)
+    + [`get-config-value($key: string, $group: string)`](#get-config-value--key--string---group--string-)
       - [Example](#example-1)
     + [`get-size($ratio-key: string)`](#-get-size--ratio-key--string--)
       - [Example](#example-2)
@@ -335,7 +335,7 @@ Using the default config:
 $dark = get-color('dark'); // #1a1a1a
 ```
 
-### get-config-value($key: string, $group: string)
+### `get-config-value($key: string, $group: string)`
 
 Returns back a 1 dimensional (key value pair) config value if available.
 

--- a/src/functions/_get-config-value.scss
+++ b/src/functions/_get-config-value.scss
@@ -9,7 +9,7 @@
   $group-items: map-get($gorko-config, $group);
 
   @if ($group-items) {
-    @return map-get($group-items, $key);
+    @return map-get(map-get($group-items, 'items'), $key);
   }
 
   @return false;


### PR DESCRIPTION
This PR adds an extra `map-get` to `get-config-value` to check the `items` map, which makes it possible to get a specific item from a config group.