### PR TITLE
Refactor inline documentation

### DIFF
--- a/gorko.scss
+++ b/gorko.scss
@@ -1,8 +1,8 @@
-// Import the default config as the fallback for if
-// the user hasn't yet set a config for their project
+/// Import the default config as the fallback for if
+/// the user hasn't yet set a config for their project
 @import './src/default-config';
 
-// Set default feature flags
+/// Set default feature flags
 $outputTokenCSS: true !default;
 
 @import './src/functions/functions';

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 A tiny, Sass-powered utility class generator, with handy helpers, that helps you to power your front-ends with a single source of truth.
 
-## Table of contents 
+## Table of contents
 
 - [Gorko](#gorko)
   * [Getting started](#getting-started)
@@ -61,21 +61,19 @@ This will generate utility classes based on the default configuration. To config
 This is the default configuration. It is recommended that you use it as your base for your own configuration.
 
 ```scss
-/**
- * BASE SIZE
- * All calculations are based on this. It’s recommended that
- * you keep it at 1rem because that is the root font size. You
- * can set it to whatever you like and whatever unit you like.
- */
+/// BASE SIZE
+/// All calculations are based on this. It’s recommended that
+/// you keep it at 1rem because that is the root font size. You
+/// can set it to whatever you like and whatever unit you like.
+///
 $gorko-base-size: 1rem !default;
 
-/**
- * SIZE SCALE
- * This is a Major Third scale that powers all the utilities that
- * it is relevant for (font-size, margin, padding). All items are
- * calcuated off the base size, so change that and cascade across
- * your whole project.
- */
+/// SIZE SCALE
+/// This is a Major Third scale that powers all the utilities that
+/// it is relevant for (font-size, margin, padding). All items are
+/// calcuated off the base size, so change that and cascade across
+/// your whole project.
+///
 $gorko-size-scale: (
   '300': $gorko-base-size * 0.8,
   '400': $gorko-base-size,
@@ -85,21 +83,19 @@ $gorko-size-scale: (
   '900': $gorko-base-size * 3
 ) !default;
 
-/**
- * COLORS
- * Colors are shared between backgrounds and text by default. 
- * You can also use them to power borders, fills or shadows, for example.
- */
+/// COLORS
+/// Colors are shared between backgrounds and text by default.
+/// You can also use them to power borders, fills or shadows, for example.
+///
 $gorko-colors: (
   'dark': #1a1a1a,
   'light': #f3f3f3
 ) !default;
 
-/**
- * CORE CONFIG
- * This powers everything from utility class generation to breakpoints
- * to enabling/disabling pre-built components/utilities.
- */
+/// CORE CONFIG
+/// This powers everything from utility class generation to breakpoints
+/// to enabling/disabling pre-built components/utilities.
+///
 $gorko-config: (
   'bg': (
     'items': $gorko-colors,

--- a/src/_default-config.scss
+++ b/src/_default-config.scss
@@ -1,109 +1,105 @@
-/**
- * BASE SIZE
- * All calculations are based on this. It’s recommended that
- * you keep it at 1rem because that is the root font size. You
- * can set it to whatever you like and whatever unit you like.
- */
+/// BASE SIZE
+/// All calculations are based on this. It’s recommended that
+/// you keep it at 1rem because that is the root font size. You
+/// can set it to whatever you like and whatever unit you like.
+///
 $gorko-base-size: 1rem !default;
 
-/**
- * SIZE SCALE
- * This is a Major Third scale that powers all the utilities that
- * it is relevant for (font-size, margin, padding). All items are
- * calcuated off the base size, so change that and cascade across
- * your whole project.
- */
+/// SIZE SCALE
+/// This is a Major Third scale that powers all the utilities that
+/// it is relevant for (font-size, margin, padding). All items are
+/// calcuated off the base size, so change that and cascade across
+/// your whole project.
+///
 $gorko-size-scale: (
   '300': $gorko-base-size * 0.8,
   '400': $gorko-base-size,
   '500': $gorko-base-size * 1.25,
   '600': $gorko-base-size * 1.6,
   '700': $gorko-base-size * 2,
-  '900': $gorko-base-size * 3
+  '900': $gorko-base-size * 3,
 ) !default;
 
-/**
- * COLORS
- * Colors are shared between backgrounds and text by default. 
- * You can also use them to power borders, fills or shadows, for example.
- */
+/// COLORS
+/// Colors are shared between backgrounds and text by default.
+/// You can also use them to power borders, fills or shadows, for example.
+///
 $gorko-colors: (
   'dark': #1a1a1a,
-  'light': #f3f3f3
+  'light': #f3f3f3,
 ) !default;
 
-/**
- * CORE CONFIG
- * This powers everything from utility class generation to breakpoints
- * to enabling/disabling pre-built components/utilities.
- */
+/// CORE CONFIG
+/// This powers everything from utility class generation to breakpoints
+/// to enabling/disabling pre-built components/utilities.
+///
 $gorko-config: (
   'bg': (
     'items': $gorko-colors,
     'output': 'standard',
-    'property': 'background'
+    'property': 'background',
   ),
   'color': (
     'items': $gorko-colors,
     'output': 'standard',
-    'property': 'color'
+    'property': 'color',
   ),
   'box': (
     'items': (
       'block': 'block',
       'flex': 'flex',
       'hide': 'none',
-      'show': 'inherit'
+      'show': 'inherit',
     ),
     'output': 'responsive',
-    'property': 'display'
+    'property': 'display',
   ),
   'font': (
     'items': (
-      'base': 'Helvetica, Arial, sans-serif'
+      'base': 'Helvetica, Arial, sans-serif',
     ),
     'output': 'standard',
-    'property': 'font-family'
+    'property': 'font-family',
   ),
   'gap-top': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'margin-top'
+    'property': 'margin-top',
   ),
   'gap-right': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'margin-right'
+    'property': 'margin-right',
   ),
   'gap-bottom': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'margin-bottom'
+    'property': 'margin-bottom',
   ),
   'gap-left': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'margin-left'
+    'property': 'margin-left',
   ),
   'pad-top': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'padding-top'
+    'property': 'padding-top',
   ),
   'pad-right': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'padding-right'
+    'property': 'padding-right',
   ),
   'pad-bottom': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'padding-bottom'
+    'property': 'padding-bottom',
   ),
   'pad-left': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'padding-left'
+    'property': 'padding-left',
   ),
   'stack': (
     'items': (
@@ -111,38 +107,38 @@ $gorko-config: (
       '400': 10,
       '500': 20,
       '600': 30,
-      '700': 40
+      '700': 40,
     ),
     'output': 'standard',
-    'property': 'z-index'
+    'property': 'z-index',
   ),
   'text': (
     'items': $gorko-size-scale,
     'output': 'responsive',
-    'property': 'font-size'
+    'property': 'font-size',
   ),
   'weight': (
     'items': (
       'light': '300',
       'regular': '400',
-      'bold': '700'
+      'bold': '700',
     ),
     'output': 'standard',
-    'property': 'font-weight'
+    'property': 'font-weight',
   ),
   'width': (
     'items': (
       'full': '100%',
       'half': percentage(1/2),
       'quarter': percentage(1/4),
-      'third': percentage(1/3)
+      'third': percentage(1/3),
     ),
     'output': 'responsive',
-    'property': 'width'
+    'property': 'width',
   ),
   'breakpoints': (
     'sm': '(min-width: 36em)',
     'md': '(min-width: 48em)',
-    'lg': '(min-width: 62em)'
-  )
+    'lg': '(min-width: 62em)',
+  ),
 ) !default;

--- a/src/_default-config.scss
+++ b/src/_default-config.scss
@@ -17,7 +17,7 @@ $gorko-size-scale: (
   '500': $gorko-base-size * 1.25,
   '600': $gorko-base-size * 1.6,
   '700': $gorko-base-size * 2,
-  '900': $gorko-base-size * 3,
+  '900': $gorko-base-size * 3
 ) !default;
 
 /// COLORS
@@ -26,7 +26,7 @@ $gorko-size-scale: (
 ///
 $gorko-colors: (
   'dark': #1a1a1a,
-  'light': #f3f3f3,
+  'light': #f3f3f3
 ) !default;
 
 /// CORE CONFIG
@@ -37,69 +37,69 @@ $gorko-config: (
   'bg': (
     'items': $gorko-colors,
     'output': 'standard',
-    'property': 'background',
+    'property': 'background'
   ),
   'color': (
     'items': $gorko-colors,
     'output': 'standard',
-    'property': 'color',
+    'property': 'color'
   ),
   'box': (
     'items': (
       'block': 'block',
       'flex': 'flex',
       'hide': 'none',
-      'show': 'inherit',
+      'show': 'inherit'
     ),
     'output': 'responsive',
-    'property': 'display',
+    'property': 'display'
   ),
   'font': (
     'items': (
-      'base': 'Helvetica, Arial, sans-serif',
+      'base': 'Helvetica, Arial, sans-serif'
     ),
     'output': 'standard',
-    'property': 'font-family',
+    'property': 'font-family'
   ),
   'gap-top': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'margin-top',
+    'property': 'margin-top'
   ),
   'gap-right': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'margin-right',
+    'property': 'margin-right'
   ),
   'gap-bottom': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'margin-bottom',
+    'property': 'margin-bottom'
   ),
   'gap-left': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'margin-left',
+    'property': 'margin-left'
   ),
   'pad-top': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'padding-top',
+    'property': 'padding-top'
   ),
   'pad-right': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'padding-right',
+    'property': 'padding-right'
   ),
   'pad-bottom': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'padding-bottom',
+    'property': 'padding-bottom'
   ),
   'pad-left': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'padding-left',
+    'property': 'padding-left'
   ),
   'stack': (
     'items': (
@@ -107,38 +107,38 @@ $gorko-config: (
       '400': 10,
       '500': 20,
       '600': 30,
-      '700': 40,
+      '700': 40
     ),
     'output': 'standard',
-    'property': 'z-index',
+    'property': 'z-index'
   ),
   'text': (
     'items': $gorko-size-scale,
     'output': 'responsive',
-    'property': 'font-size',
+    'property': 'font-size'
   ),
   'weight': (
     'items': (
       'light': '300',
       'regular': '400',
-      'bold': '700',
+      'bold': '700'
     ),
     'output': 'standard',
-    'property': 'font-weight',
+    'property': 'font-weight'
   ),
   'width': (
     'items': (
       'full': '100%',
       'half': percentage(1/2),
       'quarter': percentage(1/4),
-      'third': percentage(1/3),
+      'third': percentage(1/3)
     ),
     'output': 'responsive',
-    'property': 'width',
+    'property': 'width'
   ),
   'breakpoints': (
     'sm': '(min-width: 36em)',
     'md': '(min-width: 48em)',
-    'lg': '(min-width: 62em)',
+    'lg': '(min-width: 62em)'
   ),
 ) !default;

--- a/src/functions/_get-color.scss
+++ b/src/functions/_get-color.scss
@@ -1,11 +1,9 @@
-/**
- * GET COLOR FUNCTION
- *
- * Function tries to match the passed $key with the $gorko-colors map. Returns null
- * if it can’t find a match.
- *
- * @param {string} $key - The color that you want to get 
- */
+/// GET COLOR FUNCTION
+/// Function tries to match the passed $key with the $gorko-colors map. Returns null
+/// if it can’t find a match.
+///
+/// @param {string} $key - The color that you want to get
+///
 @function get-color($key) {
   $response: map-get($gorko-colors, $key);
 

--- a/src/functions/_get-config-value.scss
+++ b/src/functions/_get-config-value.scss
@@ -1,10 +1,9 @@
-/**
- * GET CONFIG VALUE FUNCTION
- * Returns back a 1 dimensional (key value pair) config value if available.
- *
- * @param {string} $key - The key of the config value that you want
- * @param {string{ $group - The group within $gorko-config where that $key lives
- */
+/// GET CONFIG VALUE FUNCTION
+/// Returns back a 1 dimensional (key value pair) config value if available.
+///
+/// @param {string} $key - The key of the config value that you want
+/// @param {string} $group - The group within $gorko-config where that $key lives
+///
 @function get-config-value($key, $group) {
   $group-items: map-get($gorko-config, $group);
 

--- a/src/functions/_get-size.scss
+++ b/src/functions/_get-size.scss
@@ -1,11 +1,10 @@
-/**
- * GET SIZE FUNCTION
- *
- * Function tries to match the passed $ratio-key with the $gorko-size-scale. Returns null
- * if it can’t find a match.
- *
- * @param {string} $ratio-key - The size ratio that you want to get 
- */
+/// GET SIZE FUNCTION
+///
+/// Function tries to match the passed $ratio-key with the $gorko-size-scale. Returns null
+/// if it can’t find a match.
+///
+/// @param {string} $ratio-key - The size ratio that you want to get
+///
 @function get-size($ratio-key) {
   $response: map-get($gorko-size-scale, $ratio-key);
 

--- a/src/generator/_generator.scss
+++ b/src/generator/_generator.scss
@@ -1,11 +1,11 @@
 @import 'workers/cycle';
 
-// Only run if there should be an output
+/// Only run if there should be an output
 @if ($outputTokenCSS == true) {
-  // Run the standard cycle first
+  /// Run the standard cycle first
   @include cycle('', false);
 
-  // For each breakpoint, generate a prefix and run the cycle
+  /// For each breakpoint, generate a prefix and run the cycle
   @each $key, $value in map-get($gorko-config, 'breakpoints') {
     $prefix: #{$key + '\\:'};
     $is-breakpoint: true;

--- a/src/generator/workers/_cycle.scss
+++ b/src/generator/workers/_cycle.scss
@@ -1,11 +1,10 @@
-/**
- * CYCLE MIXIN
- * A simple worker that loops every element in the config
- * and pushes it into the collection processor
- * 
- * @param {string} $prefix - An optional prefix that is stuck to the front of selectors
- * @param {bool} $is-breakpoint - A flag for the responsive generation to use to determine wether to run or not
- */
+/// CYCLE MIXIN
+/// A simple worker that loops every element in the config
+/// and pushes it into the collection processor
+///
+/// @param {string} $prefix - An optional prefix that is stuck to the front of selectors
+/// @param {bool} $is-breakpoint - A flag for the responsive generation to use to determine wether to run or not
+///
 @import 'process-collection';
 
 @mixin cycle($prefix, $is-breakpoint) {

--- a/src/generator/workers/_generate-css.scss
+++ b/src/generator/workers/_generate-css.scss
@@ -1,12 +1,11 @@
-/**
- * GENERATE CSS MIXIN
- * The final CSS generator that takes the process params and generates
- * a CSS utility.
- *
- * @param {string} $selector - The CSS selector that should be generated
- * @param {string} $property - The CSS property that this utility affects
- * @param {map} $items - The collection of utility items to generate classes for
- */
+/// GENERATE CSS MIXIN
+/// The final CSS generator that takes the process params and generates
+/// a CSS utility.
+///
+/// @param {string} $selector - The CSS selector that should be generated
+/// @param {string} $property - The CSS property that this utility affects
+/// @param {map} $items - The collection of utility items to generate classes for
+///
 @mixin generate-css($selector, $property, $items) {
   @each $key, $value in $items {
     #{'.' + $selector + '-' + $key} {

--- a/src/generator/workers/_process-collection.scss
+++ b/src/generator/workers/_process-collection.scss
@@ -1,15 +1,13 @@
-/**
- * PROCESS COLLECTION MIXIN
- * Takes a passed collection and finds utility classes to generate. 
- * It’ll loop through breakpoints, too and generate responsive utilities 
- * where required
- *
- * @param {map} $collection - The '$gorko-config' config item 
- * @param {string} $prefix - An optional prefix that is stuck to the front of selectors
- * @param {string} $selector - The CSS selector that should be generated
- * @param {bool} $is-breakpoint - A flag for the responsive generation to use to determine wether to run or not
- */
-
+/// PROCESS COLLECTION MIXIN
+/// Takes a passed collection and finds utility classes to generate.
+/// It’ll loop through breakpoints, too and generate responsive utilities
+/// where required
+///
+/// @param {map} $collection - The '$gorko-config' config item
+/// @param {string} $prefix - An optional prefix that is stuck to the front of selectors
+/// @param {string} $selector - The CSS selector that should be generated
+/// @param {bool} $is-breakpoint - A flag for the responsive generation to use to determine wether to run or not
+///
 @import 'generate-css';
 
 @mixin process-collection($collection, $prefix, $selector, $is-breakpoint) {
@@ -17,7 +15,7 @@
   $output: map-get($collection, 'output');
   $property: map-get($collection, 'property');
 
-  // It'll only run if $items and $property aren't null. This means it'll ignore the breakpoints, for example.
+  /// It'll only run if $items and $property aren't null. This means it'll ignore the breakpoints, for example.
   @if ($property and $items) {
     @if ($output == 'responsive') {
       @include generate-css(#{$prefix + $selector}, $property, $items);

--- a/src/mixins/_apply-utility.scss
+++ b/src/mixins/_apply-utility.scss
@@ -1,11 +1,10 @@
-/**
- * APPLY UTILITY MIXIN
- * Grab the property and value of one of the $gorko-config utilities
- * that the generator will generate a class for. 
- *
- * @param {string} $key - The configured utility’s key
- * @param {string} $value-key - The value key that you are looking for within the utilty
- */
+/// APPLY UTILITY MIXIN
+/// Grab the property and value of one of the $gorko-config utilities
+/// that the generator will generate a class for.
+///
+/// @param {string} $key - The configured utility’s key
+/// @param {string} $value-key - The value key that you are looking for within the utilty
+///
 @mixin apply-utility($key, $value-key) {
   $utility: map-get($gorko-config, $key);
   $property: map-get($utility, 'property');

--- a/src/mixins/_media-query.scss
+++ b/src/mixins/_media-query.scss
@@ -1,10 +1,9 @@
-/**
- * MEDIA QUERY MIXIN
- * Pass in the key of one of your breakpoints set in `$gorko-config['breakpoints']`
- * and this mixin will generate the @media query with your configured value.
- *
- * @param {string} $key - The key of your configured breakpoint
- */
+/// MEDIA QUERY MIXIN
+/// Pass in the key of one of your breakpoints set in `$gorko-config['breakpoints']`
+/// and this mixin will generate the @media query with your configured value.
+///
+/// @param {string} $key - The key of your configured breakpoint
+///
 @mixin media-query($key) {
   $breakpoints: map-get($gorko-config, 'breakpoints');
   $matched-breakpoint: map-get($breakpoints, $key);


### PR DESCRIPTION
Change all comments to Documentation Comments (see Sass Docs)

Hi Andy,
I'm working on a Style Stage style and I was very curious about CUBE and Gorko. So far nothing but praise! The only thing is that the inline documentation is included when I generate the stylesheet. I've found in the Sass docs that there's a special type of comment for this that prevents this. See link below.

https://sass-lang.com/documentation/syntax/comments#documentation-comments