### PR TITLE
Add a way to generate CSS custom properties with Design tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gorko",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "A tiny Sass token class generator.",
   "main": "gorko.scss",
   "dependencies": {

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ A tiny, Sass-powered utility class generator, with handy helpers, that helps you
     + [`$gorko-colors` (optional)](#--gorko-colors---optional-)
     + [`$gorko-config` (required)](#--gorko-config---required-)
     + [Breakpoints](#breakpoints)
-    + [Design tokens](#design-tokens)
+    + [CSS Custom Properties](#css-custom-properties)
   * [Utility Class Generator](#utility-class-generator)
       - [Example outputs](#example-outputs)
   * [Sass functions](#sass-functions)
@@ -246,7 +246,7 @@ The `breakpoints` map in `$gorko-config` defines media queries for the utility c
 
 You can add as many or as little of these as you like and call them whatever you like. The only requirement is that the value is a valid media query.
 
-### Design tokens
+### CSS Custom Properties
 
 The `tokens` map in `$gorko-config` defines [CSS custom properties](https://developer.mozilla.org/en-US/docs/Web/CSS/--*) which can be used by the utility class generator. The key will be the name of the design token and the value is a map of token types. Here is an example config:
 
@@ -264,14 +264,21 @@ The `tokens` map in `$gorko-config` defines [CSS custom properties](https://deve
 The utility class generator loops through `$gorko-config` looking for items that have a valid utility class structure. The following structure is required to generate a utility class:
 
 ```scss
-'width':('items':('full':'100%','half': '50%',
-	),
-	'output': 'standard',
-	'property': 'width'
-),;
+'width': (
+  'items': (
+    'full': '100%',
+    'half': '50%'
+  ),
+  'output': 'standard',
+  'property': 'width'
+),
+
 ```
 
-The first key is the name of the utility and that contains a Sass map. Inside that map, you need to have the following: - `items`: a map of key/value pairs which link a utility class to a CSS property’s value - `output`: this must be `responsive` or `standard`. If you set it to `responsive`, it will generate the same utility class for **every breakpoint that is defined**. - `property`: the [CSS property](https://css-tricks.com/almanac/properties/) that this utility controls.
+The first key is the name of the utility and that contains a Sass map. Inside that map, you need to have the following: 
+- `items`: a map of key/value pairs which link a utility class to a CSS property’s value. If you want to use CSS Custom Properties, this should be the string key, referencing the `'css-vars'` `$gorko-config` group that you want to use 
+- `output`: this must be `responsive` or `standard`. If you set it to `responsive`, it will generate the same utility class for **every breakpoint that is defined**.
+- `property`: the [CSS property](https://css-tricks.com/almanac/properties/) that this utility controls.
 
 #### Example outputs
 
@@ -329,34 +336,51 @@ If we set the `output` to be `responsive`, with the default `breakpoints` define
 }
 ```
 
-### `use-design-token`
+## Using CSS Custom Properties
 
-Optionally you can define `use-design-token` with a [`design-tokens`](#design-tokens) key as the value in the utility class structure. This will set the property value as the design token CSS custom property.
+You might want to use CSS Custom Properties instead of static references to tokens. To do so with Gorko, you need to make a couple of adjustments to your `$gorko-config`. 
 
-#### Example
+Firstly, at the top, you need to add a `css-vars` group which has a **key** and a value, which should be a map of tokens. 
 
 ```scss
 $gorko-config: (
-  'design-tokens': (
-    'color': $gorko-colors
-  ),
-  'bg': (
-    'items': $gorko-colors,
-    'output': 'standard',
-    'property': 'background',
-    'use-design-token': 'color'
+  'css-vars': (
+    'color': $gorko-colors,
+    'weight': (
+	    'bold': 700,
+	    'black': 900
+    )
   )
 )
 ```
 
-The above config will output:
+In this example, we have defined a `'color'` group which uses `$gorko-colors`, but also a `'weight'` group where we have defined key value pairs, just like we do in the utility class generator. 
+
+This will now generate a collection of CSS Custom properties like this: 
 
 ```css
 :root {
   --color-dark: #1a1a1a;
   --color-light: #f3f3f3;
+  --weight-bold: 700;
+  --weight-black: 900;
 }
+```
 
+To use CSS Custom Properties in a utility class, we need to first, switch `'items'` to be a reference to the `'css-vars'` group we want, then set `'css-vars'` to be `true`.
+
+```scss
+'bg': (
+  'items': 'color',
+  'css-vars': true,
+  'output': 'standard',
+  'property': 'background'
+)
+```
+
+Now, the background utility classes will look like this:
+
+```css
 .bg-dark {
   background: var(--color-dark);
 }
@@ -365,6 +389,8 @@ The above config will output:
   background: var(--color-light);
 }
 ```
+
+**Note**: You can use a combination of CSS Custom Properties _and_ static references to tokens for different utility classes. Gorko is flexible enough to let you do what works for you and your team.
 
 ## Sass functions
 

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,7 @@ A tiny, Sass-powered utility class generator, with handy helpers, that helps you
     + [`$gorko-colors` (optional)](#--gorko-colors---optional-)
     + [`$gorko-config` (required)](#--gorko-config---required-)
     + [Breakpoints](#breakpoints)
+    + [Design tokens](#design-tokens)
   * [Utility Class Generator](#utility-class-generator)
       - [Example outputs](#example-outputs)
   * [Sass functions](#sass-functions)
@@ -245,6 +246,19 @@ The `breakpoints` map in `$gorko-config` defines media queries for the utility c
 
 You can add as many or as little of these as you like and call them whatever you like. The only requirement is that the value is a valid media query.
 
+### Design tokens
+
+The `design-tokens` map in `$gorko-config` defines [CSS custom properties](https://developer.mozilla.org/en-US/docs/Web/CSS/--*) which can be used by the utility class generator. The key will be the name of the design token and the value is a map of token types. Here is an example config:
+
+```scss
+'design-tokens': (
+  'color': (
+    'dark': #1a1a1a,
+    'light': #f3f3f3
+  )
+)
+```
+
 ## Utility Class Generator
 
 The utility class generator loops through `$gorko-config` looking for items that have a valid utility class structure. The following structure is required to generate a utility class:
@@ -312,6 +326,43 @@ If we set the `output` to be `responsive`, with the default `breakpoints` define
   .lg\:width-half {
     width: 50%;
   }
+}
+```
+
+### `use-design-token`
+
+Optionally you can define `use-design-token` with a [`design-tokens`](#design-tokens) key as the value in the utility class structure. This will set the property value as the design token CSS custom property.
+
+#### Example
+
+```scss
+$gorko-config: (
+  'design-tokens': (
+    'color': $gorko-colors
+  ),
+  'bg': (
+    'items': $gorko-colors,
+    'output': 'standard',
+    'property': 'background',
+    'use-design-token': 'color'
+  )
+)
+```
+
+The above config will output:
+
+```css
+:root {
+  --color-dark: #1a1a1a;
+  --color-light: #f3f3f3;
+}
+
+.bg-dark {
+  background: var(--color-dark);
+}
+
+.bg-light {
+  background: var(--color-light);
 }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -246,19 +246,6 @@ The `breakpoints` map in `$gorko-config` defines media queries for the utility c
 
 You can add as many or as little of these as you like and call them whatever you like. The only requirement is that the value is a valid media query.
 
-### CSS Custom Properties
-
-The `tokens` map in `$gorko-config` defines [CSS custom properties](https://developer.mozilla.org/en-US/docs/Web/CSS/--*) which can be used by the utility class generator. The key will be the name of the design token and the value is a map of token types. Here is an example config:
-
-```scss
-'design-tokens': (
-  'color': (
-    'dark': #1a1a1a,
-    'light': #f3f3f3
-  )
-)
-```
-
 ## Utility Class Generator
 
 The utility class generator loops through `$gorko-config` looking for items that have a valid utility class structure. The following structure is required to generate a utility class:
@@ -347,8 +334,8 @@ $gorko-config: (
   'css-vars': (
     'color': $gorko-colors,
     'weight': (
-	    'bold': 700,
-	    'black': 900
+      'bold': 700,
+      'black': 900
     )
   )
 )

--- a/readme.md
+++ b/readme.md
@@ -248,7 +248,7 @@ You can add as many or as little of these as you like and call them whatever you
 
 ### Design tokens
 
-The `design-tokens` map in `$gorko-config` defines [CSS custom properties](https://developer.mozilla.org/en-US/docs/Web/CSS/--*) which can be used by the utility class generator. The key will be the name of the design token and the value is a map of token types. Here is an example config:
+The `tokens` map in `$gorko-config` defines [CSS custom properties](https://developer.mozilla.org/en-US/docs/Web/CSS/--*) which can be used by the utility class generator. The key will be the name of the design token and the value is a map of token types. Here is an example config:
 
 ```scss
 'design-tokens': (

--- a/src/_default-config.scss
+++ b/src/_default-config.scss
@@ -34,15 +34,23 @@ $gorko-colors: (
 /// to enabling/disabling pre-built components/utilities.
 ///
 $gorko-config: (
+  'tokens': (
+    'size': $gorko-size-scale,
+    'color': $gorko-colors
+  ),
   'bg': (
     'items': $gorko-colors,
     'output': 'standard',
     'property': 'background',
+    'css-vars': true,
+    'token-group': 'color'
   ),
   'color': (
     'items': $gorko-colors,
     'output': 'standard',
     'property': 'color',
+    'css-vars': true,
+    'token-group': 'color'
   ),
   'box': (
     'items': (
@@ -115,7 +123,9 @@ $gorko-config: (
   'text': (
     'items': $gorko-size-scale,
     'output': 'responsive',
-    'property': 'font-size'
+    'property': 'font-size',
+    'css-vars': true,
+    'token-group': 'size'
   ),
   'weight': (
     'items': (

--- a/src/_default-config.scss
+++ b/src/_default-config.scss
@@ -34,19 +34,13 @@ $gorko-colors: (
 /// to enabling/disabling pre-built components/utilities.
 ///
 $gorko-config: (
-  'css-vars': (
-    'size': $gorko-size-scale,
-    'color': $gorko-colors
-  ),
   'bg': (
-    'items': 'color',
-    'css-vars': true,
+    'items': $gorko-colors,
     'output': 'standard',
     'property': 'background'
   ),
   'color': (
-    'items': 'color',
-    'css-vars': true,
+    'items': $gorko-colors,
     'output': 'standard',
     'property': 'color'
   ),
@@ -119,8 +113,7 @@ $gorko-config: (
     'property': 'z-index'
   ),
   'text': (
-    'items': 'size',
-    'css-vars': true,
+    'items': $gorko-size-scale,
     'output': 'responsive',
     'property': 'font-size'
   ),

--- a/src/_default-config.scss
+++ b/src/_default-config.scss
@@ -34,21 +34,15 @@ $gorko-colors: (
 /// to enabling/disabling pre-built components/utilities.
 ///
 $gorko-config: (
-  'design-tokens': (
-    'color': $gorko-colors,
-    'size': $gorko-size-scale,
-  ),
   'bg': (
     'items': $gorko-colors,
     'output': 'standard',
     'property': 'background',
-    'use-design-token': 'color',
   ),
   'color': (
     'items': $gorko-colors,
     'output': 'standard',
     'property': 'color',
-    'use-design-token': 'color',
   ),
   'box': (
     'items': (
@@ -70,50 +64,42 @@ $gorko-config: (
   'gap-top': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'margin-top',
-    'use-design-token': 'size',
+    'property': 'margin-top'
   ),
   'gap-right': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'margin-right',
-    'use-design-token': 'size',
+    'property': 'margin-right'
   ),
   'gap-bottom': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'margin-bottom',
-    'use-design-token': 'size',
+    'property': 'margin-bottom'
   ),
   'gap-left': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'margin-left',
-    'use-design-token': 'size',
+    'property': 'margin-left'
   ),
   'pad-top': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'padding-top',
-    'use-design-token': 'size',
+    'property': 'padding-top'
   ),
   'pad-right': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'padding-right',
-    'use-design-token': 'size',
+    'property': 'padding-right'
   ),
   'pad-bottom': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'padding-bottom',
-    'use-design-token': 'size',
+    'property': 'padding-bottom'
   ),
   'pad-left': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'padding-left',
-    'use-design-token': 'size',
+    'property': 'padding-left'
   ),
   'stack': (
     'items': (
@@ -129,8 +115,7 @@ $gorko-config: (
   'text': (
     'items': $gorko-size-scale,
     'output': 'responsive',
-    'property': 'font-size',
-    'use-design-token': 'size',
+    'property': 'font-size'
   ),
   'weight': (
     'items': (

--- a/src/_default-config.scss
+++ b/src/_default-config.scss
@@ -34,15 +34,21 @@ $gorko-colors: (
 /// to enabling/disabling pre-built components/utilities.
 ///
 $gorko-config: (
+  'design-tokens': (
+    'color': $gorko-colors,
+    'size': $gorko-size-scale,
+  ),
   'bg': (
     'items': $gorko-colors,
     'output': 'standard',
-    'property': 'background'
+    'property': 'background',
+    'use-design-token': 'color',
   ),
   'color': (
     'items': $gorko-colors,
     'output': 'standard',
-    'property': 'color'
+    'property': 'color',
+    'use-design-token': 'color',
   ),
   'box': (
     'items': (
@@ -64,42 +70,50 @@ $gorko-config: (
   'gap-top': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'margin-top'
+    'property': 'margin-top',
+    'use-design-token': 'size',
   ),
   'gap-right': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'margin-right'
+    'property': 'margin-right',
+    'use-design-token': 'size',
   ),
   'gap-bottom': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'margin-bottom'
+    'property': 'margin-bottom',
+    'use-design-token': 'size',
   ),
   'gap-left': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'margin-left'
+    'property': 'margin-left',
+    'use-design-token': 'size',
   ),
   'pad-top': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'padding-top'
+    'property': 'padding-top',
+    'use-design-token': 'size',
   ),
   'pad-right': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'padding-right'
+    'property': 'padding-right',
+    'use-design-token': 'size',
   ),
   'pad-bottom': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'padding-bottom'
+    'property': 'padding-bottom',
+    'use-design-token': 'size',
   ),
   'pad-left': (
     'items': $gorko-size-scale,
     'output': 'standard',
-    'property': 'padding-left'
+    'property': 'padding-left',
+    'use-design-token': 'size',
   ),
   'stack': (
     'items': (
@@ -115,7 +129,8 @@ $gorko-config: (
   'text': (
     'items': $gorko-size-scale,
     'output': 'responsive',
-    'property': 'font-size'
+    'property': 'font-size',
+    'use-design-token': 'size',
   ),
   'weight': (
     'items': (

--- a/src/_default-config.scss
+++ b/src/_default-config.scss
@@ -34,23 +34,21 @@ $gorko-colors: (
 /// to enabling/disabling pre-built components/utilities.
 ///
 $gorko-config: (
-  'tokens': (
+  'css-vars': (
     'size': $gorko-size-scale,
     'color': $gorko-colors
   ),
   'bg': (
-    'items': $gorko-colors,
-    'output': 'standard',
-    'property': 'background',
+    'items': 'color',
     'css-vars': true,
-    'token-group': 'color'
+    'output': 'standard',
+    'property': 'background'
   ),
   'color': (
-    'items': $gorko-colors,
-    'output': 'standard',
-    'property': 'color',
+    'items': 'color',
     'css-vars': true,
-    'token-group': 'color'
+    'output': 'standard',
+    'property': 'color'
   ),
   'box': (
     'items': (
@@ -121,11 +119,10 @@ $gorko-config: (
     'property': 'z-index'
   ),
   'text': (
-    'items': $gorko-size-scale,
-    'output': 'responsive',
-    'property': 'font-size',
+    'items': 'size',
     'css-vars': true,
-    'token-group': 'size'
+    'output': 'responsive',
+    'property': 'font-size'
   ),
   'weight': (
     'items': (

--- a/src/generator/_generator.scss
+++ b/src/generator/_generator.scss
@@ -2,12 +2,12 @@
 
 /// Only run if there should be an output
 @if ($outputTokenCSS == true) {
-  $design-tokens: map-get($gorko-config, 'design-tokens');
+  $tokens: map-get($gorko-config, 'tokens');
   
-  @if ($design-tokens) {
+  @if ($tokens) {
     // Generate custom properties for each design token
     :root {
-      @each $token, $items in $design-tokens {
+      @each $token, $items in $tokens {
         @each $key, $value in $items {
           --#{$token + '-' + $key}: #{$value};
         }

--- a/src/generator/_generator.scss
+++ b/src/generator/_generator.scss
@@ -2,6 +2,19 @@
 
 /// Only run if there should be an output
 @if ($outputTokenCSS == true) {
+  $design-tokens: map-get($gorko-config, 'design-tokens');
+  
+  @if ($design-tokens) {
+    // Generate custom properties for each design token
+    :root {
+      @each $token, $items in $design-tokens {
+        @each $key, $value in $items {
+          --#{$token + '-' + $key}: #{$value};
+        }
+      }
+    }
+  }
+  
   /// Run the standard cycle first
   @include cycle('', false);
 

--- a/src/generator/_generator.scss
+++ b/src/generator/_generator.scss
@@ -2,19 +2,19 @@
 
 /// Only run if there should be an output
 @if ($outputTokenCSS == true) {
-  $tokens: map-get($gorko-config, 'tokens');
-  
-  @if ($tokens) {
-    // Generate custom properties for each design token
+  $cssVars: map-get($gorko-config, 'css-vars');
+
+  @if ($cssVars) {
+    // Generate custom properties for each CSS var
     :root {
-      @each $token, $items in $tokens {
+      @each $var, $items in $cssVars {
         @each $key, $value in $items {
-          --#{$token + '-' + $key}: #{$value};
+          --#{$var + '-' + $key}: #{$value};
         }
       }
     }
   }
-  
+
   /// Run the standard cycle first
   @include cycle('', false);
 

--- a/src/generator/workers/_generate-css.scss
+++ b/src/generator/workers/_generate-css.scss
@@ -5,13 +5,14 @@
 /// @param {string} $selector - The CSS selector that should be generated
 /// @param {string} $property - The CSS property that this utility affects
 /// @param {map} $items - The collection of utility items to generate classes for
-/// @param {string} $design-token - The design token key to reference the css variable
+/// @param {boolean} $use-css-vars - wip! this is to tell generate-css to use either a value or a CSS Variable
+/// @param {string} $token-group - wip! this will be the name of the CSS variable you wish to use
 ///
-@mixin generate-css($selector, $property, $items, $design-token) {
+@mixin generate-css($selector, $property, $items, $use-css-vars, $token-group) {
   @each $key, $value in $items {
     #{'.' + $selector + '-' + $key} {
-      @if ($design-token) {
-        #{ $property }: var(--#{$design-token + '-' + $key});
+      @if ($use-css-vars) {
+        #{ $property }: var(--#{$token-group + '-' + $key});
       } @else {
         #{ $property }: #{$value};
       }

--- a/src/generator/workers/_generate-css.scss
+++ b/src/generator/workers/_generate-css.scss
@@ -5,14 +5,14 @@
 /// @param {string} $selector - The CSS selector that should be generated
 /// @param {string} $property - The CSS property that this utility affects
 /// @param {map} $items - The collection of utility items to generate classes for
-/// @param {boolean} $use-css-vars - wip! this is to tell generate-css to use either a value or a CSS Variable
-/// @param {string} $token-group - wip! this will be the name of the CSS variable you wish to use
+/// @param {boolean} $use-css-vars - this is to tell generate-css to use either a value or a CSS Variable
+/// @param {string} $item-key - the key for items which is used for tying each CSS var up to the item value
 ///
-@mixin generate-css($selector, $property, $items, $use-css-vars, $token-group) {
+@mixin generate-css($selector, $property, $items, $use-css-vars, $item-key) {
   @each $key, $value in $items {
     #{'.' + $selector + '-' + $key} {
       @if ($use-css-vars) {
-        #{ $property }: var(--#{$token-group + '-' + $key});
+        #{ $property }: var(--#{$item-key + '-' + $key});
       } @else {
         #{ $property }: #{$value};
       }

--- a/src/generator/workers/_generate-css.scss
+++ b/src/generator/workers/_generate-css.scss
@@ -5,11 +5,16 @@
 /// @param {string} $selector - The CSS selector that should be generated
 /// @param {string} $property - The CSS property that this utility affects
 /// @param {map} $items - The collection of utility items to generate classes for
+/// @param {string} $design-token - The design token key to reference the css variable
 ///
-@mixin generate-css($selector, $property, $items) {
+@mixin generate-css($selector, $property, $items, $design-token) {
   @each $key, $value in $items {
     #{'.' + $selector + '-' + $key} {
-      #{ $property }: #{$value};
+      @if ($design-token) {
+        #{ $property }: var(--#{$design-token + '-' + $key});
+      } @else {
+        #{ $property }: #{$value};
+      }
     }
   }
 }

--- a/src/generator/workers/_process-collection.scss
+++ b/src/generator/workers/_process-collection.scss
@@ -14,16 +14,17 @@
   $items: map-get($collection, 'items');
   $output: map-get($collection, 'output');
   $property: map-get($collection, 'property');
+  $design-token: map-get($collection, 'use-design-token');
 
-  /// It'll only run if $items and $property aren't null. This means it'll ignore the breakpoints, for example.
+  /// It'll only run if $items and $property aren't null. This means it'll ignore the breakpoints and design tokens, for example.
   @if ($property and $items) {
     @if ($output == 'responsive') {
-      @include generate-css(#{$prefix + $selector}, $property, $items);
+      @include generate-css(#{$prefix + $selector}, $property, $items, $design-token);
     }
 
     @if ($output == 'standard') {
       @if ($is-breakpoint != true) {
-        @include generate-css(#{$prefix + $selector}, $property, $items);
+        @include generate-css(#{$prefix + $selector}, $property, $items, $design-token);
       }
     }
   }

--- a/src/generator/workers/_process-collection.scss
+++ b/src/generator/workers/_process-collection.scss
@@ -15,17 +15,37 @@
   $output: map-get($collection, 'output');
   $property: map-get($collection, 'property');
   $use-css-vars: map-get($collection, 'css-vars');
-  $token-group: map-get($collection, 'token-group');
+  $vars-key: '';
+
+  /// If this collection is using CSS vars, the items come from the
+  /// 'css-vars' map in $gorko-config
+  @if ($use-css-vars) {
+    $vars: map-get($gorko-config, 'css-vars');
+    $vars-key: map-get($collection, 'items');
+    $items: map-get($vars, $vars-key);
+  }
 
   /// It'll only run if $items and $property aren't null. This means it'll ignore the breakpoints and design tokens, for example.
   @if ($property and $items) {
     @if ($output == 'responsive') {
-      @include generate-css(#{$prefix + $selector}, $property, $items, $use-css-vars, $token-group);
+      @include generate-css(
+        #{$prefix + $selector},
+        $property,
+        $items,
+        $use-css-vars,
+        $vars-key
+      );
     }
 
     @if ($output == 'standard') {
       @if ($is-breakpoint != true) {
-        @include generate-css(#{$prefix + $selector}, $property, $items, $use-css-vars, $token-group);
+        @include generate-css(
+          #{$prefix + $selector},
+          $property,
+          $items,
+          $use-css-vars,
+          $vars-key
+        );
       }
     }
   }

--- a/src/generator/workers/_process-collection.scss
+++ b/src/generator/workers/_process-collection.scss
@@ -14,17 +14,18 @@
   $items: map-get($collection, 'items');
   $output: map-get($collection, 'output');
   $property: map-get($collection, 'property');
-  $design-token: map-get($collection, 'use-design-token');
+  $use-css-vars: map-get($collection, 'css-vars');
+  $token-group: map-get($collection, 'token-group');
 
   /// It'll only run if $items and $property aren't null. This means it'll ignore the breakpoints and design tokens, for example.
   @if ($property and $items) {
     @if ($output == 'responsive') {
-      @include generate-css(#{$prefix + $selector}, $property, $items, $design-token);
+      @include generate-css(#{$prefix + $selector}, $property, $items, $use-css-vars, $token-group);
     }
 
     @if ($output == 'standard') {
       @if ($is-breakpoint != true) {
-        @include generate-css(#{$prefix + $selector}, $property, $items, $design-token);
+        @include generate-css(#{$prefix + $selector}, $property, $items, $use-css-vars, $token-group);
       }
     }
   }


### PR DESCRIPTION
This PR adds the functionality to be able to define Design tokens to be used as CSS custom properties. This is done by adding a optional `design-tokens` map in the `$gorko-config` of your design tokens and you can add `use-design-token` to your utility structure to use the CSS custom properties for your utility classes.

Example config:

```scss
/* config.scss */
$gorko-size-scale: (
  '300': $gorko-base-size * 0.8,
  '400': $gorko-base-size,
  '500': $gorko-base-size * 1.25,
  '600': $gorko-base-size * 1.6,
  '700': $gorko-base-size * 2,
  '900': $gorko-base-size * 3
);

$gorko-colors: (
  'dark': #1a1a1a,
  'light': #f3f3f3
);

$gorko-config: (
  'design-tokens': (
    'color': $gorko-colors,
    'size': $gorko-size-scale
  ),
  'bg': (
    'items': $gorko-colors,
    'output': 'standard',
    'property': 'background',
    'use-design-token': 'color'
  ),
  'text': (
    'items': $gorko-size-scale,
    'output': 'responsive',
    'property': 'font-size',
    'use-design-token': 'size'
  ),
  'breakpoints': (
    'lg': '(min-width: 62em)'
  )
);
```

Which will compile:

```css
/* compiled.css */
:root {
  --color-dark: #1a1a1a;
  --color-light: #f3f3f3;
  --size-300: 0.8rem;
  --size-400: 1rem;
  --size-500: 1.25rem;
  --size-600: 1.6rem;
  --size-700: 2rem;
  --size-900: 3rem;
}

.bg-dark {
  background: var(--color-dark);
}

.bg-light {
  background: var(--color-light);
}

.text-300 {
  font-size: var(--size-300);
}

.text-400 {
  font-size: var(--size-400);
}

.text-500 {
  font-size: var(--size-500);
}

.text-600 {
  font-size: var(--size-600);
}

.text-700 {
  font-size: var(--size-700);
}

.text-900 {
  font-size: var(--size-900);
}

@media screen and (min-width: 62em) {
  .lg\:text-300 {
    font-size: var(--size-300);
  }

  .lg\:text-400 {
    font-size: var(--size-400);
  }

  .lg\:text-500 {
    font-size: var(--size-500);
  }

  .lg\:text-600 {
    font-size: var(--size-600);
  }

  .lg\:text-700 {
    font-size: var(--size-700);
  }

  .lg\:text-900 {
    font-size: var(--size-900);
  }
}
```

Closes #8.