### PR TITLE
Don't generate css vars twice if there are no themes

### DIFF
--- a/src/generator/workers/_generate-css-vars.scss
+++ b/src/generator/workers/_generate-css-vars.scss
@@ -43,11 +43,6 @@
           }
         }
       }
-    } @else {
-      /// No themes, so just generate custom properties for each CSS var
-      :root {
-        @include process-vars($vars);
-      }
     }
   }
 }


### PR DESCRIPTION
When running the `generate-css-vars` mixin without themes the css vars from a config file will be generated twice.

There is no need for the else branch on the $themes check as the required vars are already generated above.